### PR TITLE
Add support for alternate git forges like sourcehut or bitbucket.

### DIFF
--- a/src/base/document-early.lisp
+++ b/src/base/document-early.lisp
@@ -174,7 +174,7 @@
 (defun make-github-source-uri-fn (asdf-system github-uri &key git-version)
   "This function is a trivial wrapper around MAKE-GIT-SOURCE-URI-FN. It is
    present to avoid breaking backwards compatibility with systems already
-   dependent on MAKE-GITHUB-SOURCE-URI-FN which MAKE-GIT-SOURCE-URI-FN =
+   dependent on MAKE-GITHUB-SOURCE-URI-FN which MAKE-GIT-SOURCE-URI-FN
    supersedes."
   (make-git-source-uri-fn asdf-system github-uri :git-version git-version))
 

--- a/src/base/document-early.lisp
+++ b/src/base/document-early.lisp
@@ -168,7 +168,15 @@
   `http://<username>.github.io/<repo-name>`. It is probably a good
   idea to add sections like the @LINKS section to allow jumping
   between the repository and the gh-pages site."
+  (make-github-source-uri-fn function)
   (make-git-source-uri-fn function))
+
+(defun make-github-source-uri-fn (asdf-system github-uri &key git-version)
+  "This function is a trivial wrapper around MAKE-GIT-SOURCE-URI-FN. It is
+   present to avoid breaking backwards compatibility with systems already
+   dependent on MAKE-GITHUB-SOURCE-URI-FN which MAKE-GIT-SOURCE-URI-FN =
+   supersedes."
+  (make-git-source-uri-fn asdf-system github-uri :git-version git-version))
 
 (defun make-git-source-uri-fn (asdf-system git-forge-uri &key git-version
                                (uri-format-string "~A/blob/~A/~A#L~S"))

--- a/src/base/extension-api.lisp
+++ b/src/base/extension-api.lisp
@@ -177,7 +177,7 @@
         (call-next-method)
         (docstring object))))
 
-;;; This is bound to an EQUAL hash table in MAKE-GITHUB-SOURCE-URI-FN
+;;; This is bound to an EQUAL hash table in MAKE-GIT-SOURCE-URI-FN
 ;;; to speed up FIND-SOURCE. It's still very slow because some
 ;;; underlying Swank calls involve reading in the whole source file.
 (defvar *find-source-cache* nil)

--- a/src/document/document-util.lisp
+++ b/src/document/document-util.lisp
@@ -84,7 +84,7 @@
     :pages
     `((:objects
       (,mgl-pax::@pax-manual)
-      :source-uri-fn ,(make-github-source-uri-fn
+      :source-uri-fn ,(make-git-source-uri-fn
                        :mgl-pax
                        \"https://github.com/melisgl/mgl-pax\"))))
   ```"

--- a/src/document/document.lisp
+++ b/src/document/document.lisp
@@ -432,7 +432,7 @@
   string representing an URI. If FORMAT is :HTML and
   *DOCUMENT-MARK-UP-SIGNATURES* is true, then the locative as
   displayed in the signature will be a link to this uri. See
-  MAKE-GITHUB-SOURCE-URI-FN.
+  MAKE-GIT-SOURCE-URI-FN.
 
   PAGES may look something like this:
 


### PR DESCRIPTION
Hi Gabor! I've quite enjoyed using mgl-pax and try while hacking on [clones](https://clones.kingcons.io) the last few days. However, clones is hosted [on sourcehut](https://git.sr.ht/~kingcons/clones) which pax cannot generate URIs for natively.

I considered writing my own `make-sourcehut-source-uri-fn` but aside from duplicating most of your work, it would be nice to reuse `asdf-system-git-version` and `convert-source-location` which are not exported. It seems a small change to add support for supplying a custom format string to match the URI scheme of any arbitrary git forge. Thought I'd provide a patch to consider. Let me know what you think. Cheers and thanks again for PAX!