### PR TITLE
add support for PDF output via Pandoc

### DIFF
--- a/src/base/document-early.lisp
+++ b/src/base/document-early.lisp
@@ -146,17 +146,23 @@
   (let ((%stream (gensym))
         (%reference (gensym))
         (%arglist (gensym))
-        (%name (gensym)))
+        (%name (gensym))
+        (%want-anchor (gensym)))
     `(let ((,%stream ,stream)
            (,%reference (or ,reference *reference-being-documented*))
            (,%arglist ,arglist)
-           (,%name ,name))
-       (when (and *document-link-code*
-                  ;; Anchors are not used in this case, and with large
-                  ;; HTML pages, we stress w3m less this way.
-                  (not *document-do-not-resolve-references*))
-         (anchor ,%reference ,%stream))
+           (,%name ,name)
+           (,%want-anchor (and *document-link-code*
+                               ;; Anchors are not used in this case, and with large
+                               ;; HTML pages, we stress w3m less this way.
+                               (not *document-do-not-resolve-references*))))
+       (when (and ,%want-anchor
+                  (not (eq *format* :pandoc-pdf)))
+         (reference-anchor ,%reference ,%stream))
        (print-reference-bullet ,%reference ,%stream :name ,%name)
+       (when (and ,%want-anchor
+                  (eq *format* :pandoc-pdf))
+         (reference-anchor ,%reference ,%stream))
        (let ((*package* (or ,package (guess-package ,%reference))))
          (when (and ,%arglist (not (eq ,%arglist :not-available)))
            (write-char #\Space ,%stream)

--- a/src/navigate/locatives.lisp
+++ b/src/navigate/locatives.lisp
@@ -1221,12 +1221,15 @@ EXPORTABLE-REFERENCE-P).")
         (document-object entry stream)))))
 
 (defun format-in-package (package stream)
-  (format stream "###### \\[in package ~A~A\\]~%"
-          (escape-markdown (package-name package))
-          (if (package-nicknames *package*)
-              (format nil " with nicknames ~{~A~^, ~}"
-                      (mapcar #'escape-markdown (package-nicknames package)))
-              "")))
+  (let ((name (escape-markdown (package-name package)))
+        (nicknames (if (package-nicknames *package*)
+                       (format nil " with nicknames ~{~A~^, ~}"
+                               (mapcar #'escape-markdown (package-nicknames package)))
+                       "")))
+    (if (eq *format* :pandoc-pdf)
+        (format stream "`\\subsubsection*{\\normalfont\\sffamily[in package ~A~A]}`{=latex}~%"
+                name nicknames)
+        (format stream "###### \\[in package ~A~A\\]~%" name nicknames))))
 
 (defmethod docstring ((section section))
   nil)


### PR DESCRIPTION
This is a PR aiming to implement #26.

This is a draft for now, but generating PDF output is already possible as follows:

``` common-lisp
(uiop:with-output-file (stream "mgl-pax.pdf" :if-exists :supersede)
  (pax:document mgl-pax::@pax-manual :stream stream :format :pandoc-pdf))
```

(I thought I would need to make an octet stream, but I haven't run into any problems yet with the above.)

Though the PR is incomplete, it has brought some issues to light, which I would like to discuss.

First, I can see four ways to implement the PDF support:

1. Sprinkle `(eq *format* :pandoc-pdf)` tests everywhere so that the intermediate Markdown output need not be modified before passing it to Pandoc.

2. Generate Markdown output in the usual manner and post-process it via `POST-PROCESS-PARSE-TREE` (tentatively renamed from `POST-PROCESS-FOR-W3M` in this PR) before passing it to Pandoc. This would require some kind of `*MARKDOWN-SUBFORMAT*` (or `*MARKDOWN-SUPERFORMAT*`, to be more proper), similar to `*HTML-SUBFORMAT*`, so that within `CALL-WITH-FORMAT` we can bind `*FORMAT*` to `:MARKDOWN`, but still know that we want to generate PDF via Pandoc within `DOCUMENT`.

3. Same as 2, but use Pandoc filters rather than modifying the Markdown parse tree from Lisp.

4. A combination of 1 and either 2 or 3. A combination of 1 and 2 is what is currently done in this PR (there is no `*MARKDOWN-SUPERFORMAT*` yet, so it relies on non–`*FORMAT*`-specific behaviors). I haven't introduced my Lua filter yet, because I wanted to see how possible and easy it would be without it.

I think it would be easier to keep track of Pandoc PDF–specific requirements in a separate filter (be it Lisp or Lua), and thus I am partial to options 2 and 3; of course, this may just be because I am less familiar with the codebase. And between options 2 and 3, I am partial to option 3, first because the Lua filter could serve as an example to users of MGL-PAX who might want to further adjust the output, and second because I am lazy and the filter already exists.

In fact, another reason to prefer option 3 is that it basically offers users a hook to transform the MGL-PAX output in arbitrary ways, which is impossible (as far as I know) with the other formats. Perhaps MGL-PAX should provide a user hook to transform the parse tree before the output is generated. One possible problem with this is that if the intermediate Markdown format changes from one version to another, the filters or hooks may become incompatible. In the case of the Lua filter bundled with MGL-PAX (i.e., if we go for option 3), this isn't an issue since it can be updated at the same time as the intermediate Markdown representation.

Which of the four methods would you prefer?

Finally, some peculiarities of the MGL-PAX documentation cause issues in the PDF output of the PAX manual:

1. The most problematic issue is that all MGL-PAX docstrings are indented by two spaces, except the first line, which causes Pandoc to misinterpret things like code blocks and I think some lists (e.g., the lists with ASDF system information). It's probably possible to preprocess the docstrings to deal with this, but since this is an issue specific to MGL-PAX docstrings, I don't think it should be handled by MGL-PAX itself. (The indented lines are also visible when browsing the docstrings from within Lisp.)

2. The subheadings sometimes jump from `##` to `#####`. On second thought, this is not such a big issue. It seemed weird to me to skip a few heading levels, but the PDF output looks fine. Note that the `[in package ...]` 6th level headings I've changed to an `\hbox{}` containing the same text but in sans serif rather than bold in my Lua filter, because I found it looked nicer. This PR doesn't contain this change yet, but if you don't agree with changing it to sans serif upon seeing it, perhaps it should be configurable in some variable.

Let me know what you think.