### PR TITLE
Properly handle ASDF systems with no location information

### DIFF
--- a/dref/src/full/locatives.lisp
+++ b/dref/src/full/locatives.lisp
@@ -1064,10 +1064,13 @@
 
 (defmethod source-location* ((dref asdf-system-dref))
   (let ((system (resolve dref)))
-    `(:location
-      (:file ,(namestring (asdf/system:system-source-file system)))
-      (:position 1)
-      (:snippet ,(format nil "defsystem ~S" (dref-name dref))))))
+    (if-let (location (asdf/system:system-source-file system))
+      `(:location
+        (:file ,(namestring location))
+        (:position 1)
+        (:snippet ,(format nil "defsystem ~S" (dref-name dref))))
+      `(:error ,(format nil "ASDF system ~A doesn't contain any location information."
+                        (asdf:primary-system-name system))))))
 
 
 ;;;; PACKAGE locative

--- a/src/document/browse.lisp
+++ b/src/document/browse.lisp
@@ -506,8 +506,13 @@
               (setq root-dirname dirname-1))))))
     (values (reverse related) root-dirname)))
 
+(defun slot-value-if-bound (object slot-name &optional default)
+  (if (slot-boundp object slot-name)
+      (slot-value object slot-name)
+      default))
+
 (defun asdf-system-dirname (system)
-  (when-let (pathname (slot-value system 'asdf/component:absolute-pathname))
+  (when-let (pathname (slot-value-if-bound system 'asdf/component:absolute-pathname))
     (namestring pathname)))
 
 #+nil


### PR DESCRIPTION
On my machine (SBCL 2.5.3, ASDF 3.3.7) there is at least one system, `asdf-package-system`, which is related to `asdf:package-inferred-system` backwards-compatibility and gets pre-registered by ASDF itself, whose `asdf/component:absolute-pathname` slot is unbound by default, and where `asdf/system:system-source-file` returns `nil` independently on whether it is "loaded" or not. MGL-PAX seems to like neither fact, choking while attempting to serve the web documentation index and the system's index, respectively.