### PR TITLE
Enable `*read-eval*` while reading ASDF system metadata

### DIFF
--- a/src/document/browse.lisp
+++ b/src/document/browse.lisp
@@ -1129,6 +1129,7 @@
 
 (defun asdf-systems-and-packages-grouped ()
   (let (;; (ROOT-DIR SYSTEMS PACKAGES)
+        (*read-eval* t)
         (groups ())
         (orphan-packages))
     (flet ((add-system (dir system)

--- a/src/document/util.lisp
+++ b/src/document/util.lisp
@@ -217,13 +217,15 @@
                ,@body)))))))
 
 (defun filename-to-asdf-system-name-map ()
-  (let ((h (make-hash-table :test #'equal)))
+  (let ((h (make-hash-table :test #'equal))
+        (*read-eval* t))
     (do-asdf-files (system-name filename)
       (setf (gethash filename h) system-name))
     h))
 
 (defun filename-to-asdf-system-name (filename)
-  (let ((filename (namestring filename)))
+  (let ((filename (namestring filename))
+        (*read-eval* t))
     (do-asdf-files (system-name filename-1)
       ;; KLUDGE: Compare namestrings so that e.g. NIL vs :NEWEST in
       ;; PATHNAME-VERSION is hopefully not a diference.


### PR DESCRIPTION
Otherwise reading properties of an `asdf:package-inferred-system` whose corresponding `defpackage` contains a #. form might cause the reader to balk.